### PR TITLE
Replace missing return statement in clean_description()

### DIFF
--- a/scripts/civitai_file_manage.py
+++ b/scripts/civitai_file_manage.py
@@ -721,6 +721,7 @@ def clean_description(desc):
     except ImportError:
         print('Python module "BeautifulSoup" was not imported correctly, cannot clean description. Please try to restart or install it manually.')
         cleaned_text = desc
+    return cleaned_text.strip()
 
 def make_dir(path):
     try:


### PR DESCRIPTION
With the implementation of the improved clean_description() code from "PR#384" in commit b9bb5a9 (Jul 28), the return statement disappeared, resulting in a blank description field. I added the return statement back, as well as adding the strip() method which trims whitespace from the beginning and end of the output string.